### PR TITLE
Make ValidationError a type of Error

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,14 +77,37 @@ exports.validatePayload = function(rawBody, signature, secretKey) {
   }
 }
 
-exports.ValidationError = function(keyLabel, webhookId, ip) {
-  this.keyLabel = keyLabel
-  this.webhookId = webhookId
-  this.ip = ip
-  this.toString = function() {
-    return 'invalid webhook: ' + [keyLabel, webhookId, ip].join(' ')
-  }
+// ES5-style per Error#ES5_Custom_Error_Object page from
+// https://developer.mozilla.org/.
+function ValidationError(keyLabel, webhookId, ip, fileName, lineno) {
+  var instance = new Error('invalid webhook: ' +
+    [keyLabel, webhookId, ip].join(' '), fileName, lineno)
+
+  instance.keyLabel = keyLabel
+  instance.webhookId = webhookId
+  instance.ip = ip
+
+  Object.setPrototypeOf(instance, Object.getPrototypeOf(this))
+  Error.captureStackTrace(this, ValidationError)
+  return instance
 }
+
+ValidationError.prototype = Object.create(Error.prototype, {
+  constructor: {
+    value: Error,
+    enumberable: false,
+    writable: true,
+    configurable: true
+  }
+})
+
+if (Object.setPrototypeOf) {
+  Object.setPrototypeOf(ValidationError, Error)
+} else {
+  ValidationError.__proto__ = Error
+}
+
+exports.ValidationError = ValidationError
 
 exports.parseKeyLabelFromBranch = function(rawBody) {
   var branchMatch = new RegExp('"ref": ?"refs/heads/([^"]*)"').exec(rawBody)
@@ -103,7 +126,7 @@ exports.middlewareValidator = function(keyDictionary, parseKeyLabelFromBody) {
     var secretKey = keyDictionary[keyLabel] || keyDictionary['<default>']
 
     if (!exports.validatePayload(rawBody, signature, secretKey)) {
-      throw new exports.ValidationError(keyLabel, webhookId, req.ip)
+      throw new ValidationError(keyLabel, webhookId, req.ip)
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-/* jshint node: true */
-
 'use strict'
 
 var bufferEq = require('buffer-equal-constant-time')

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "mocha test",
     "mocha": "mocha",
-    "lint": "eslint *.js"
+    "lint": "eslint *.js test/*.js"
   },
   "repository": {
     "type": "git",

--- a/test/index.js
+++ b/test/index.js
@@ -1,26 +1,23 @@
-/* jshint node: true */
-/* jshint expr: true */
-/* jshint mocha: true */
-'use strict';
+'use strict'
 
-var path = require('path');
-var chai = require('chai');
-var chaiAsPromised = require('chai-as-promised');
-var httpMocks = require('node-mocks-http');
-var crypto = require('crypto');
-var validator = require('../index');
+var path = require('path')
+var chai = require('chai')
+var chaiAsPromised = require('chai-as-promised')
+var httpMocks = require('node-mocks-http')
+var crypto = require('crypto')
+var validator = require('../index')
 
-var expect = chai.expect;
-chai.should();
-chai.use(chaiAsPromised);
+var expect = chai.expect
+chai.should()
+chai.use(chaiAsPromised)
 
 function makeSignature(payload, secret) {
   return 'sha1=' +
-    crypto.createHmac('sha1', secret).update(payload, 'utf8').digest('hex');
+    crypto.createHmac('sha1', secret).update(payload, 'utf8').digest('hex')
 }
 
 function check(done, cb) {
-  return function(err) { try { cb(err); done(); } catch (e) { done(e); } };
+  return function(err) { try { cb(err); done() } catch (e) { done(e) } }
 }
 
 describe('PayloadValidator', function() {
@@ -28,260 +25,260 @@ describe('PayloadValidator', function() {
     'secret0',
     'secret1',
     'secret2'
-  ].map(function (item) { return path.join(__dirname, 'data', item); });
-  var defaultKeyPath = path.join(__dirname, 'data', 'defaultKey');
+  ].map(function (item) { return path.join(__dirname, 'data', item) })
+  var defaultKeyPath = path.join(__dirname, 'data', 'defaultKey')
 
   describe('getKeyFiles', function() {
     it('should return an empty array if no files specified', function() {
-      expect(validator.getKeyFiles(undefined)).to.be.empty;
-    });
+      expect(validator.getKeyFiles(undefined)).to.be.empty
+    })
 
     it('should provide the default key file only', function() {
       expect(validator.getKeyFiles('keys/defaultKey')).to.eql([
         { label: '<default>', file: 'keys/defaultKey' }
-      ]);
-    });
+      ])
+    })
 
     it('should provide only branch keys with keys', function() {
       var branchConfigs = [
         { branch: 'foo', secretKeyFile: 'keys/fooKey' },
         { branch: 'bar' },
         { branch: 'baz', secretKeyFile: 'keys/barKey' }
-      ];
+      ]
       expect(validator.getKeyFiles('keys/defaultKey', branchConfigs)).to.eql([
         { label: 'foo', file: 'keys/fooKey' },
         { label: 'baz', file: 'keys/barKey' },
         { label: '<default>', file: 'keys/defaultKey' }
-      ]);
-    });
-  });
+      ])
+    })
+  })
 
   describe('loadKeyFile', function() {
     it('should fail for a nonexistent file', function() {
       return validator.loadKeyFile('<default>', 'nonexistent_file')
-        .should.be.rejectedWith(Error, 'nonexistent_file: ENOENT');
-    });
+        .should.be.rejectedWith(Error, 'nonexistent_file: ENOENT')
+    })
 
     it('should succeed for an existing key file', function() {
       return validator.loadKeyFile('<default>', keyPaths[0])
-        .should.become({ label: '<default>', key: 'deadbeef' });
-    });
-  });
+        .should.become({ label: '<default>', key: 'deadbeef' })
+    })
+  })
 
   describe('loadKeyDictionary', function() {
     it('should return an empty dictionary if no keys defined', function() {
-      return validator.loadKeyDictionary().should.become({});
-    });
+      return validator.loadKeyDictionary().should.become({})
+    })
 
     it('should provide the default key file only', function() {
       return validator.loadKeyDictionary(defaultKeyPath)
-        .should.become({ '<default>': 'default secret' });
-    });
+        .should.become({ '<default>': 'default secret' })
+    })
 
     it('should provide the default key and every branch key', function() {
       var branchConfigs = [
         { branch: 'foo', secretKeyFile: keyPaths[0] },
         { branch: 'bar', secretKeyFile: keyPaths[1] },
         { branch: 'baz', secretKeyFile: keyPaths[2] }
-      ];
+      ]
       return validator.loadKeyDictionary(defaultKeyPath, branchConfigs)
         .should.become({
           '<default>': 'default secret',
           'foo': 'deadbeef',
           'bar': 'feedbead',
-          'baz': 'secret the third',
-        });
-    });
+          'baz': 'secret the third'
+        })
+    })
 
     it('should not create branch entries if no default', function() {
       var branchConfigs = [
         { branch: 'foo', secretKeyFile: keyPaths[0] },
         { branch: 'bar' },
         { branch: 'baz', secretKeyFile: keyPaths[2] }
-      ];
+      ]
       return validator.loadKeyDictionary(undefined, branchConfigs)
         .should.become({
           'foo': 'deadbeef',
-          'baz': 'secret the third',
-        });
-    });
+          'baz': 'secret the third'
+        })
+    })
 
     it('should fail if a key file fails to open', function() {
       var branchConfigs = [
         { branch: 'foo', secretKeyFile: keyPaths[0] },
         { branch: 'bar', secretKeyFile: 'nonexistent_file' },
         { branch: 'baz', secretKeyFile: keyPaths[2] }
-      ];
+      ]
       return validator.loadKeyDictionary(undefined, branchConfigs)
-        .should.be.rejectedWith(Error, 'nonexistent_file: ENOENT');
-    });
-  });
+        .should.be.rejectedWith(Error, 'nonexistent_file: ENOENT')
+    })
+  })
 
   describe('validatePayload', function() {
-    var payload = '{ "ref": "refs/heads/18f-pages" }';
-    var secret = 'deadbeef';
-    var signature = makeSignature(payload, secret);
+    var payload = '{ "ref": "refs/heads/18f-pages" }'
+    var secret = 'deadbeef'
+    var signature = makeSignature(payload, secret)
 
     it('should pass if no signature and no secret defined', function() {
-      expect(validator.validatePayload(payload)).to.be.true;
-    });
+      expect(validator.validatePayload(payload)).to.be.true
+    })
 
     it('should fail if signature defined and no secret defined', function() {
-      expect(validator.validatePayload(payload, signature)).to.be.false;
-    });
+      expect(validator.validatePayload(payload, signature)).to.be.false
+    })
 
     it('should fail if signature not defined and secret defined', function() {
-      expect(validator.validatePayload(payload, null, secret)).to.be.false;
-    });
+      expect(validator.validatePayload(payload, null, secret)).to.be.false
+    })
 
     it('should pass if signature matches payload', function() {
-      expect(validator.validatePayload(payload, signature, secret)).to.be.true;
-    });
+      expect(validator.validatePayload(payload, signature, secret)).to.be.true
+    })
 
     it('should fail if signature does not match payload', function() {
       expect(validator.validatePayload(payload, signature, secret + ' extra'))
-        .to.be.false;
-    });
+        .to.be.false
+    })
 
     it('should fail if the signature algorithm is not supported', function() {
-      var algorithmAndHash = signature.split('=');
-      signature = 'foobar=' + algorithmAndHash[1];
+      var algorithmAndHash = signature.split('=')
+      signature = 'foobar=' + algorithmAndHash[1]
       expect(validator.validatePayload(payload, signature, secret))
-        .to.be.false;
-    });
+        .to.be.false
+    })
 
     it('should properly handle strings with UTF-8 characters', function() {
       // Note the apostrophe in `it’s` is a UTF-8 smart quote.
       var payload = '"description": "Guide to help agencies understand what ' +
-        'it’s like to work with 18F. ",';
-      signature = makeSignature(payload, secret);
+        'it’s like to work with 18F. ",'
+      signature = makeSignature(payload, secret)
       expect(signature).to.equal(
-        'sha1=6364b3c77dc014e0226e541fc47615141e54428d');
-      expect(validator.validatePayload(payload, signature, secret)).to.be.true;
-    });
-  });
+        'sha1=6364b3c77dc014e0226e541fc47615141e54428d')
+      expect(validator.validatePayload(payload, signature, secret)).to.be.true
+    })
+  })
 
   describe('parseKeyLabelFromBranch', function() {
-    var payload = '{ "ref": "refs/heads/18f-pages" }';
+    var payload = '{ "ref": "refs/heads/18f-pages" }'
 
     it('should parse the branch from the payload', function() {
-      expect(validator.parseKeyLabelFromBranch(payload)).to.eql('18f-pages');
-    });
+      expect(validator.parseKeyLabelFromBranch(payload)).to.eql('18f-pages')
+    })
 
     it('should return null if no branch ref is present', function() {
-      expect(validator.parseKeyLabelFromBranch('')).to.be.null;
-    });
-  });
+      expect(validator.parseKeyLabelFromBranch('')).to.be.null
+    })
+  })
 
   describe('middlewareValidator', function() {
-    var payload;
-    var keyDictionary;
-    var webhookId = '01234567-0123-0123-1234-0123456789ab';
-    var ipAddr = '127.0.0.1';
-    var httpOptions;
+    var payload
+    var keyDictionary
+    var webhookId = '01234567-0123-0123-1234-0123456789ab'
+    var ipAddr = '127.0.0.1'
+    var httpOptions
 
     beforeEach(function() {
-      payload = '{ "ref": "refs/heads/18f-pages" }';
-      keyDictionary = {};
-      httpOptions = { headers: { 'X-GitHub-Delivery': webhookId } };
-    });
+      payload = '{ "ref": "refs/heads/18f-pages" }'
+      keyDictionary = {}
+      httpOptions = { headers: { 'X-GitHub-Delivery': webhookId } }
+    })
 
     var addSignatureToHttpHeaders = function(rawBody, secret) {
-      httpOptions.headers['X-Hub-Signature'] = makeSignature(rawBody, secret);
-    };
+      httpOptions.headers['X-Hub-Signature'] = makeSignature(rawBody, secret)
+    }
 
     var loadKeyDictionary = function(done) {
       var branchConfigs = [
-        { branch: '18f-pages', secretKeyFile: keyPaths[0] },
-      ];
+        { branch: '18f-pages', secretKeyFile: keyPaths[0] }
+      ]
       validator.loadKeyDictionary(defaultKeyPath, branchConfigs)
-        .then(function(dictionary) { keyDictionary = dictionary; done(); })
-        .catch(done);
-    };
+        .then(function(dictionary) { keyDictionary = dictionary; done() })
+        .catch(done)
+    }
 
     var middlewareValidatorTestWrapper = function(rawBody) {
-      var validate = validator.middlewareValidator(keyDictionary);
-      var req = httpMocks.createRequest(httpOptions);
-      req.ip = ipAddr;
-      return function() { validate(req, undefined, rawBody, 'utf8'); };
-    };
+      var validate = validator.middlewareValidator(keyDictionary)
+      var req = httpMocks.createRequest(httpOptions)
+      req.ip = ipAddr
+      return function() { validate(req, undefined, rawBody, 'utf8') }
+    }
 
     var expectedErrorMsg = function(label) {
-      return 'invalid webhook: ' + [label, webhookId, ipAddr].join(' ');
-    };
+      return 'invalid webhook: ' + [label, webhookId, ipAddr].join(' ')
+    }
 
     it('should pass if no keys defined', function() {
       expect(middlewareValidatorTestWrapper(payload))
-        .to.not.throw(validator.ValidationError);
-    });
+        .to.not.throw(validator.ValidationError)
+    })
 
     it('should fail if no keys defined but signature present', function() {
-      addSignatureToHttpHeaders(payload, 'some bogus secret');
+      addSignatureToHttpHeaders(payload, 'some bogus secret')
       expect(middlewareValidatorTestWrapper(payload)).to.throw(
-        validator.ValidationError, expectedErrorMsg('18f-pages'));
-    });
+        validator.ValidationError, expectedErrorMsg('18f-pages'))
+    })
 
     it('should pass if signature matches branch secret', function(done) {
       loadKeyDictionary(check(done, function() {
-        addSignatureToHttpHeaders(payload, keyDictionary['18f-pages']);
+        addSignatureToHttpHeaders(payload, keyDictionary['18f-pages'])
         expect(middlewareValidatorTestWrapper(payload))
-          .to.not.throw(validator.ValidationError);
-      }));
-    });
+          .to.not.throw(validator.ValidationError)
+      }))
+    })
 
     it('should pass even if no space between key and value', function(done) {
       loadKeyDictionary(check(done, function() {
-        payload = '{ "ref":"refs/heads/18f-pages" }';
-        addSignatureToHttpHeaders(payload, keyDictionary['18f-pages']);
+        payload = '{ "ref":"refs/heads/18f-pages" }'
+        addSignatureToHttpHeaders(payload, keyDictionary['18f-pages'])
         expect(middlewareValidatorTestWrapper(payload))
-          .to.not.throw(validator.ValidationError);
-      }));
-    });
+          .to.not.throw(validator.ValidationError)
+      }))
+    })
 
     it('should pass if branch signature matches default', function(done) {
       loadKeyDictionary(check(done, function() {
-        payload = '{ "ref": "refs/heads/18f-pages-use-default" }';
-        addSignatureToHttpHeaders(payload, keyDictionary['<default>']);
+        payload = '{ "ref": "refs/heads/18f-pages-use-default" }'
+        addSignatureToHttpHeaders(payload, keyDictionary['<default>'])
         expect(middlewareValidatorTestWrapper(payload))
-          .to.not.throw(validator.ValidationError);
-      }));
-    });
+          .to.not.throw(validator.ValidationError)
+      }))
+    })
 
     it('should pass if no label parsed but matches default', function(done) {
       loadKeyDictionary(check(done, function() {
-        payload = '{ "not_a_ref": "but still signed content" }';
-        addSignatureToHttpHeaders(payload, keyDictionary['<default>']);
+        payload = '{ "not_a_ref": "but still signed content" }'
+        addSignatureToHttpHeaders(payload, keyDictionary['<default>'])
         expect(middlewareValidatorTestWrapper(payload))
-          .to.not.throw(validator.ValidationError);
-      }));
-    });
+          .to.not.throw(validator.ValidationError)
+      }))
+    })
 
     it('should fail if signature does not match secret', function(done) {
       loadKeyDictionary(check(done, function() {
-        addSignatureToHttpHeaders(payload, 'some bogus secret');
+        addSignatureToHttpHeaders(payload, 'some bogus secret')
         expect(middlewareValidatorTestWrapper(payload)).to.throw(
-          validator.ValidationError, expectedErrorMsg('18f-pages'));
-      }));
-    });
+          validator.ValidationError, expectedErrorMsg('18f-pages'))
+      }))
+    })
 
     it('should fail if branch without secret and no default', function(done) {
       loadKeyDictionary(check(done, function() {
-        payload = '{ "ref": "refs/heads/18f-pages-use-default" }';
-        addSignatureToHttpHeaders(payload, keyDictionary['<default>']);
-        keyDictionary['<default>'] = undefined;
+        payload = '{ "ref": "refs/heads/18f-pages-use-default" }'
+        addSignatureToHttpHeaders(payload, keyDictionary['<default>'])
+        keyDictionary['<default>'] = undefined
         expect(middlewareValidatorTestWrapper(payload)).to.throw(
-          validator.ValidationError, expectedErrorMsg('18f-pages-use-default'));
-      }));
-    });
+          validator.ValidationError, expectedErrorMsg('18f-pages-use-default'))
+      }))
+    })
 
     it('should fail if no label parsed and no default defined', function(done) {
       loadKeyDictionary(check(done, function() {
-        payload = '{ "not_a_ref": "but still signed content" }';
-        addSignatureToHttpHeaders(payload, keyDictionary['<default>']);
-        keyDictionary['<default>'] = undefined;
+        payload = '{ "not_a_ref": "but still signed content" }'
+        addSignatureToHttpHeaders(payload, keyDictionary['<default>'])
+        keyDictionary['<default>'] = undefined
         expect(middlewareValidatorTestWrapper(payload)).to.throw(
-          validator.ValidationError, expectedErrorMsg('<default>'));
-      }));
-    });
-  });
-});
+          validator.ValidationError, expectedErrorMsg('<default>'))
+      }))
+    })
+  })
+})

--- a/test/index.js
+++ b/test/index.js
@@ -170,6 +170,21 @@ describe('PayloadValidator', function() {
     })
   })
 
+  describe('ValidationError', function() {
+    it('should be an Error', function() {
+      try {
+        throw new validator.ValidationError('foobar', 'bazquux', '127.0.0.1')
+      } catch (err) {
+        err.keyLabel.should.equal('foobar')
+        err.webhookId.should.equal('bazquux')
+        err.ip.should.equal('127.0.0.1')
+        err.toString().should.equal('Error: invalid webhook: ' +
+          'foobar bazquux 127.0.0.1')
+        err.should.be.an('Error')
+      }
+    })
+  })
+
   describe('middlewareValidator', function() {
     var payload
     var keyDictionary


### PR DESCRIPTION
Updating the packages from https://github.com/mbland/pages-server resulted in some failing tests due to a newer version of `body-parser` using the `http-errors` package to set the status code on errors ([`body-parser` v1.18.0 / 2017-09-08][bp]). This new implementation should ensure that the `http-errors` package uses the ValidationError information, now that it itself extends `Error`.

[bp]: https://github.com/expressjs/body-parser/blob/master/HISTORY.md#1180--2017-09-08

Also adhered to the [ES5 implementation][es5], since Node v4.8.5 doesn't support the [ES6 implementation][es6].

[es5]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#ES5_Custom_Error_Object
[es6]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Custom_Error_Types

Also contains lint updates missed in #1.